### PR TITLE
Add specification paths kb building

### DIFF
--- a/repo.path
+++ b/repo.path
@@ -3,3 +3,7 @@ ostis-web-platform/ims.ostis.kb
 
 # components
 kb/
+
+# specifications
+problem-solver/cxx/exampleModule/specifications/agent_of_isomorphic_search
+problem-solver/cxx/exampleModule/specifications/agent_of_subdividing_search


### PR DESCRIPTION
Add specification paths for kb building
Due to their absence, it was impossible to call agent of isomorphic search and agent of subdividing search.