### PR TITLE
fix: add missed CMakeLists.txt

### DIFF
--- a/problem-solver/cxx/example-module/CMakeLists.txt
+++ b/problem-solver/cxx/example-module/CMakeLists.txt
@@ -1,0 +1,25 @@
+file(GLOB SOURCES CONFIGURE_DEPENDS
+    "*.cpp" "*.hpp"
+    "agents/*.cpp" "agents/*.hpp"
+    "keynodes/*.hpp"
+    "structures/*.cpp" "structures/*.hpp"
+    "searcher/*.cpp" "searcher/*.hpp"
+    "utils/*.cpp" "utils/*.hpp")
+
+add_library(example-module SHARED ${SOURCES})
+target_link_libraries(example-module
+    LINK_PUBLIC sc-machine::sc-memory
+    LINK_PUBLIC sc-machine::sc-agents-common
+)
+target_include_directories(example-module
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_target_properties(example-module PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/extensions)
+
+if(${SC_CLANG_FORMAT_CODE})
+    target_clangformat_setup(example-module)
+endif()
+
+if(${SC_BUILD_TESTS})
+    add_subdirectory(test)
+endif ()

--- a/problem-solver/cxx/example-module/test/CMakeLists.txt
+++ b/problem-solver/cxx/example-module/test/CMakeLists.txt
@@ -1,0 +1,25 @@
+file(GLOB TEST_UTILS_SOURCES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_LIST_DIR}/utils/*.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/utils/*.hpp")
+
+add_library(example-module-test-utils STATIC ${TEST_UTILS_SOURCES})
+target_link_libraries(example-module-test-utils
+    LINK_PUBLIC example-module
+    LINK_PUBLIC GTest::gtest_main)
+
+target_include_directories(example-module-test-utils
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+if(${SC_CLANG_FORMAT_CODE})
+    target_clangformat_setup(example-module-test-utils)
+endif()
+
+make_tests_from_folder(${CMAKE_CURRENT_LIST_DIR}/units
+    NAME example-module-tests
+    DEPENDS sc-machine::sc-builder-lib example-module-test-utils
+)
+
+if(${SC_CLANG_FORMAT_CODE})
+    target_clangformat_setup(example-module-tests)
+endif()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add missing `CMakeLists.txt` files for `example-module` and its tests to define build configurations and dependencies.
> 
>   - **Build System**:
>     - Add `CMakeLists.txt` to `example-module` to define sources and build `example-module` as a shared library.
>     - Add `CMakeLists.txt` to `example-module/test` to define test utilities and build `example-module-test-utils` as a static library.
>   - **Dependencies**:
>     - Link `example-module` with `sc-machine::sc-memory` and `sc-machine::sc-agents-common`.
>     - Link `example-module-test-utils` with `example-module` and `GTest::gtest_main`.
>   - **Configuration**:
>     - Set `LIBRARY_OUTPUT_DIRECTORY` for `example-module`.
>     - Include directories for both `example-module` and `example-module-test-utils`.
>     - Conditional setup for `clang-format` and test directory inclusion based on `SC_CLANG_FORMAT_CODE` and `SC_BUILD_TESTS`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-apps%2Fostis-example-app&utm_source=github&utm_medium=referral)<sup> for c2c0ab5aab3404ea21d2d598d87381a6ee9d2872. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->