### PR TITLE
feat(docs): add example of building tests in release mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Steps for installing and running the application directly on your system.
     source .venv/bin/activate && python3 server/app.py
     ```
     
-    Starts the web interface. `source .venv/bin/activate` activates the virtual environment for `sc-web`, and `python3 server/app.py` starts the web server.
+    Starts the `sc-web`. `source .venv/bin/activate` activates the virtual environment for `sc-web`, and `python3 server/app.py` starts the web server.
 
 3.  **Access interface:** Open `localhost:8000` in your web browser.
 
@@ -302,6 +302,13 @@ Then open `http://127.0.0.1:8005/` in your browser.
     conan install . --build=missing -s build_type=Debug
     cmake --preset debug-conan
     cmake --build --preset debug
+    ```
+
+    For release mode with tests:
+
+    ```sh
+    cmake --preset release-with-tests-conan
+    cmake --build --preset release
     ```
 
     To enable debug logs, configure `ostis-example-app.ini`:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds example for building in release mode with tests to `README.md`.
> 
>   - **Documentation**:
>     - Adds example for building in release mode with tests in `README.md` using `cmake --preset release-with-tests-conan` and `cmake --build --preset release`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-apps%2Fostis-example-app&utm_source=github&utm_medium=referral)<sup> for 0c8a8843cc60f408dd9cae731f85b5eaaf8512c7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->