### PR TITLE
[docs] Mention Ctrl+C to stop servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ Steps for installing and running the application directly on your system.
 
     ![Example Screenshot](https://i.imgur.com/6SehI5s.png)
 
+To stop the running servers for the ostis-example-app, press `Ctrl+C` in the terminals where sc-machine and sc-web are running.
+
 ## Documentation
 
 To generate local documentation:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `Ctrl+C` instruction to stop servers in `README.md`.
> 
>   - **Documentation**:
>     - Added instruction in `README.md` to stop running servers for ostis-example-app using `Ctrl+C` in terminals where `sc-machine` and `sc-web` are running.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-apps%2Fostis-example-app&utm_source=github&utm_medium=referral)<sup> for 5cdfc05f27d5e69ce61860f9255cdf6db24b7d30. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->