### PR TITLE
Add scl-machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 bin/
 build/
-sc-machine/
+install/
 *.bin
 repo
 

--- a/README.md
+++ b/README.md
@@ -174,25 +174,15 @@ Steps for installing and running the application directly on your system.
     
     `--build=missing` builds dependencies from source if pre-built binaries are not available.
 
-8.  **Install sc-machine binaries:**
+8.  **Install sc-machine and scl-machine binaries:**
    
     sc-machine binaries are pre-compiled executables that provide the runtime environment for the ostis-system: build knowledge base source and launch the ostis-system. The installation process differs slightly between Linux and macOS:
 
-    *   **Linux:**
-
-        ```sh
-        curl -LO https://github.com/ostis-ai/sc-machine/releases/download/0.10.0/sc-machine-0.10.0-Linux.tar.gz
-        mkdir sc-machine && tar -xvzf sc-machine-0.10.0-Linux.tar.gz -C sc-machine --strip-components 1
-        rm -rf sc-machine-0.10.0-Linux.tar.gz && rm -rf sc-machine/include
-        ```
-
-    *   **macOS:**
-
-        ```sh
-        curl -LO https://github.com/ostis-ai/sc-machine/releases/download/0.10.0/sc-machine-0.10.0-Darwin.tar.gz
-        mkdir sc-machine && tar -xvzf sc-machine-0.10.0-Darwin.tar.gz -C sc-machine --strip-components 1
-        rm -rf sc-machine-0.10.0-Darwin.tar.gz && rm -rf sc-machine/include
-        ```
+    scl-machine binaries are pre-compiled modules with agents of logical inferences.
+    
+    ```sh
+    ./scripts/install_cxx_problem_solver.sh
+    ```
     
     Downloads and extracts pre-built `sc-machine` binaries for your operating system. The `include` directory is removed because it is not required.
 
@@ -240,7 +230,7 @@ Steps for installing and running the application directly on your system.
     The knowledge base contains your custom knowledge represented in SC-code. It needs to be built before launching the system or after making changes:
 
     ```sh
-    ./sc-machine/bin/sc-builder -i repo.path -o kb.bin --clear
+    ./install/sc-machine/bin/sc-builder -i repo.path -o kb.bin --clear
     ```
     
     This command builds the knowledge base from the `.scs` and `.gwf` files in the `knowledge-base` directory, creating the `kb.bin` file. The `--clear` flag clears the knowledge base before building.
@@ -250,7 +240,8 @@ Steps for installing and running the application directly on your system.
 1.  **Start `sc-machine` (in a terminal):**
 
     ```sh
-    ./sc-machine/bin/sc-machine -s kb.bin -e "sc-machine/lib/extensions;build/Release/extensions"
+    ./install/sc-machine/bin/sc-machine -s kb.bin \
+        -e "install/sc-machine/lib/extensions;install/scl-machine/lib/extensions;build/Release/extensions"
     ```
     
     Starts the `sc-machine`, loading the knowledge base (`kb.bin`) and specifying the paths to the extensions.
@@ -288,7 +279,7 @@ Then open `http://127.0.0.1:8005/` in your browser.
 *   **`knowledge-base`**: Contains the knowledge base source files (`.scs`, `.gwf`). Rebuild the knowledge base after making changes:
 
     ```sh
-    ./sc-machine/bin/sc-builder -i repo.path -o kb.bin --clear
+    ./install/sc-machine/bin/sc-builder -i repo.path -o kb.bin --clear
     ```
 
 *   **`problem-solver`**: Contains the C++ agents that implement the problem-solving logic. Rebuild after modifying:

--- a/problem-solver/cxx/example-module/CMakeLists.txt
+++ b/problem-solver/cxx/example-module/CMakeLists.txt
@@ -4,7 +4,8 @@ file(GLOB SOURCES CONFIGURE_DEPENDS
     "keynodes/*.hpp"
     "structures/*.cpp" "structures/*.hpp"
     "searcher/*.cpp" "searcher/*.hpp"
-    "utils/*.cpp" "utils/*.hpp")
+    "utils/*.cpp" "utils/*.hpp"
+)
 
 add_library(example-module SHARED ${SOURCES})
 target_link_libraries(example-module
@@ -22,4 +23,4 @@ endif()
 
 if(${SC_BUILD_TESTS})
     add_subdirectory(test)
-endif ()
+endif()

--- a/scripts/install_cxx_problem_solver.sh
+++ b/scripts/install_cxx_problem_solver.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Constants
+SC_MACHINE_VERSION="0.10.0"
+SC_MACHINE_DESTINATION_DIR="install/sc-machine"
+
+SCL_MACHINE_VERSION="0.3.0"
+SCL_MACHINE_DESTINATION_DIR="install/scl-machine"
+
+get_archive_name() {
+    local os_name=$(uname -s)
+    case "$os_name" in
+        Linux)
+            echo "$1-$2-Linux.tar.gz"
+            ;;
+        Darwin)
+            echo "$1-$2-Darwin.tar.gz"
+            ;;
+        *)
+            echo "Unsupported operating system: $os_name"
+            exit 1
+            ;;
+    esac
+}
+
+download_archive() {
+    local url="$1"
+    echo "Downloading ${url}..."
+    if ! curl -LO "${url}"; then
+        echo "Error downloading ${url}"
+        exit 1
+    fi
+}
+
+extract_archive() {
+    local archive="$1"
+    local destination_dir="$2"
+    echo "Creating directory ${destination_dir} and extracting files..."
+    mkdir -p "${destination_dir}" && tar -xvzf "${archive}" -C "${destination_dir}" --strip-components 1
+}
+
+cleanup() {
+    local archive="$1"
+    local destination_dir="$2"
+    echo "Cleaning up..."
+    rm -f "${archive}"
+    rm -rf "${destination_dir}/include"
+}
+
+SC_MACHINE_ARCHIVE=$(get_archive_name "sc-machine" "${SC_MACHINE_VERSION}")
+SC_MACHINE_URL="https://github.com/ostis-ai/sc-machine/releases/download/${SC_MACHINE_VERSION}/${SC_MACHINE_ARCHIVE}"
+
+download_archive "${SC_MACHINE_URL}"
+extract_archive "${SC_MACHINE_ARCHIVE}" "${SC_MACHINE_DESTINATION_DIR}"
+cleanup "${SC_MACHINE_ARCHIVE}" "${SC_MACHINE_DESTINATION_DIR}"
+
+SCL_MACHINE_ARCHIVE=$(get_archive_name "scl-machine" "${SCL_MACHINE_VERSION}")
+SCL_MACHINE_URL="https://github.com/ostis-ai/scl-machine/releases/download/${SCL_MACHINE_VERSION}/${SCL_MACHINE_ARCHIVE}"
+
+download_archive "${SCL_MACHINE_URL}"
+extract_archive "${SCL_MACHINE_ARCHIVE}" "${SCL_MACHINE_DESTINATION_DIR}"
+cleanup "${SCL_MACHINE_ARCHIVE}" "${SCL_MACHINE_DESTINATION_DIR}"
+
+echo "Installation complete!"


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `scl-machine` binaries installation and automate with `install_cxx_problem_solver.sh` script.
> 
>   - **Behavior**:
>     - Adds installation instructions for `scl-machine` binaries in `README.md`.
>     - Updates `sc-machine` installation paths in `README.md`.
>     - Introduces `install_cxx_problem_solver.sh` script to automate downloading and installing `sc-machine` and `scl-machine` binaries.
>   - **Scripts**:
>     - New script `install_cxx_problem_solver.sh` handles downloading, extracting, and cleaning up `sc-machine` and `scl-machine` binaries.
>   - **Misc**:
>     - Minor formatting fix in `CMakeLists.txt` for `example-module`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-apps%2Fostis-example-app&utm_source=github&utm_medium=referral)<sup> for e1b41002b1993e61ef58ee3c7656c3906e8e6949. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->


Depends on https://github.com/ostis-ai/scl-machine/pull/83