### PR TITLE
add scl path variable into CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,11 @@ endforeach(OUTPUT_CONFIG CMAKE_CONFIGURATION_TYPES)
 set(CMAKE_SCRIPTS_FOLDER "${CMAKE_CURRENT_LIST_DIR}/cmake")
 include(${CMAKE_SCRIPTS_FOLDER}/common.cmake)
 
+set(SUBSYSTEMS_PATH "${CMAKE_CURRENT_LIST_DIR}/subsystems")
+set(SCL_MACHINE_PS_PATH "${SUBSYSTEMS_PATH}/scl-machine/problem-solver")
+set(INFERENCE_MODULE_PATH "${SCL_MACHINE_PS_PATH}/cxx/inferenceModule")
+
+add_subdirectory(${SCL_MACHINE_PS_PATH}/)
+
 add_subdirectory(problem-solver)
 
-set(SUBSYSTEMS_PATH "${CMAKE_CURRENT_LIST_DIR}/subsystems")
-subdir_list(SUBDIRS ${SUBSYSTEMS_PATH})
-
-foreach(SUBDIR ${SUBDIRS})
-    add_subdirectory(${SUBSYSTEMS_PATH}/${SUBDIR}/problem-solver)
-endforeach()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `SCL_MACHINE_PS_PATH` and `INFERENCE_MODULE_PATH` variables to `CMakeLists.txt` and reorder `add_subdirectory` calls.
> 
>   - **CMake Path Variables**:
>     - Added `SCL_MACHINE_PS_PATH` and `INFERENCE_MODULE_PATH` variables in `CMakeLists.txt`.
>   - **Subdirectory Order**:
>     - Changed order of `add_subdirectory` calls to include `${SCL_MACHINE_PS_PATH}/` before `problem-solver`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-apps%2Fostis-example-app&utm_source=github&utm_medium=referral)<sup> for 42bef2e3a64f9997bab5fa6530d96bba1d13fafc. You can [customize](https://app.ellipsis.dev/ostis-apps/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->