### PR TITLE
[scripts][docker] Add using non-atomic-action-interpreter-module

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - "KB_PATH=/knowledge-base/repo.path"
       - "BINARY_PATH=/example-app/install/sc-machine/bin"
       - "CONFIG_PATH=/knowledge-base/ostis-example-app.ini"
-      - "EXTENSIONS_PATH=/example-app/build/Release/extensions;/example-app/install/sc-machine/lib/extensions;/example-app/install/scl-machine/lib/extensions"
+      - "EXTENSIONS_PATH=/example-app/build/Release/extensions;/example-app/install/sc-machine/lib/extensions;/example-app/install/scl-machine/lib/extensions;/example-app/install/non-atomic-action-interpreter-module/lib/extensions"
       - "SC_SERVER_HOST=0.0.0.0"
     command:
       - "run"

--- a/scripts/install_cxx_problem_solver.sh
+++ b/scripts/install_cxx_problem_solver.sh
@@ -8,6 +8,9 @@ SC_MACHINE_DESTINATION_DIR="install/sc-machine"
 SCL_MACHINE_VERSION="0.3.0"
 SCL_MACHINE_DESTINATION_DIR="install/scl-machine"
 
+NON_ATOMIC_ACTION_INTERPRETER_MODULE_VERSION="0.1.0"
+NON_ATOMIC_ACTION_INTERPRETER_MODULE_DESTINATION_DIR="install/non-atomic-action-interpreter-module"
+
 get_archive_name() {
     local os_name=$(uname -s)
     case "$os_name" in
@@ -61,5 +64,12 @@ SCL_MACHINE_URL="https://github.com/ostis-ai/scl-machine/releases/download/${SCL
 download_archive "${SCL_MACHINE_URL}"
 extract_archive "${SCL_MACHINE_ARCHIVE}" "${SCL_MACHINE_DESTINATION_DIR}"
 cleanup "${SCL_MACHINE_ARCHIVE}" "${SCL_MACHINE_DESTINATION_DIR}"
+
+NON_ATOMIC_ACTION_INTERPRETER_MODULE_ARCHIVE=$(get_archive_name "non-atomic-action-interpreter-module" "${NON_ATOMIC_ACTION_INTERPRETER_MODULE_VERSION}")
+NON_ATOMIC_ACTION_INTERPRETER_MODULE_URL="https://github.com/ostis-ai/ostis-ps-lib/releases/download/${NON_ATOMIC_ACTION_INTERPRETER_MODULE_VERSION}/${NON_ATOMIC_ACTION_INTERPRETER_MODULE_ARCHIVE}"
+
+download_archive "${NON_ATOMIC_ACTION_INTERPRETER_MODULE_URL}"
+extract_archive "${NON_ATOMIC_ACTION_INTERPRETER_MODULE_ARCHIVE}" "${NON_ATOMIC_ACTION_INTERPRETER_MODULE_DESTINATION_DIR}"
+cleanup "${NON_ATOMIC_ACTION_INTERPRETER_MODULE_ARCHIVE}" "${NON_ATOMIC_ACTION_INTERPRETER_MODULE_DESTINATION_DIR}"
 
 echo "Installation complete!"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `non-atomic-action-interpreter-module` in Docker and installation scripts.
> 
>   - **Docker Configuration**:
>     - Add `non-atomic-action-interpreter-module` to `EXTENSIONS_PATH` in `docker-compose.yml`.
>   - **Installation Script**:
>     - Define `NON_ATOMIC_ACTION_INTERPRETER_MODULE_VERSION` and `NON_ATOMIC_ACTION_INTERPRETER_MODULE_DESTINATION_DIR` in `install_cxx_problem_solver.sh`.
>     - Add download, extraction, and cleanup steps for `non-atomic-action-interpreter-module` in `install_cxx_problem_solver.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-apps%2Fostis-example-app&utm_source=github&utm_medium=referral)<sup> for 6a922e2e04f08a1efd32bbfafaa7c5e6635f509a. You can [customize](https://app.ellipsis.dev/ostis-apps/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->